### PR TITLE
Fix matadata typo in `Compliance Checker`

### DIFF
--- a/src/components/compliance/BeatmapCard.tsx
+++ b/src/components/compliance/BeatmapCard.tsx
@@ -74,7 +74,7 @@ export default function BeatmapCard({ beatmap, notes = null }: BeatmapCardProps)
                 {["graveyard", "pending", "wip"].includes(beatmap.beatmapset.status) && (
                     <Text size="sm" c="orange" lineClamp={2}>
                         <FontAwesomeIcon icon="triangle-exclamation" /> Graveyard/Pending beatmaps don't always have
-                        correct matadata.
+                        correct metadata.
                     </Text>
                 )}
             </Stack>


### PR DESCRIPTION
As mentioned by [niat0004](https://osu.ppy.sh/users/10797776) in [#tournaments](https://discord.com/channels/188630481301012481/867773019015610389/1355181286372937728) in Discord.