### PR TITLE
Update ak+q and overrides

### DIFF
--- a/server/constants/artist-permissions/flagged.json
+++ b/server/constants/artist-permissions/flagged.json
@@ -19,6 +19,10 @@
         "status": "partial",
         "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
     },
+    "Lusumi": {
+        "status": "partial",
+        "notes": "Do not use the track titled 'execution_program'."
+    },
     "Morimori Atsushi": {
         "status": "partial",
         "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."

--- a/server/constants/artist-permissions/flagged.json
+++ b/server/constants/artist-permissions/flagged.json
@@ -1,86 +1,86 @@
 {
-  "a_hisa": {
-    "status": "partial",
-    "notes": "Contact before uploading. Can be reached via email or Bandcamp."
-  },
-  "Akira Complex": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "HoneyComeBear": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "Jun Kuroda": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "Morimori Atsushi": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "Synthion": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "Yuyoyuppe": {
-    "status": "partial",
-    "notes": "Tracks from or themed around Touhou should not be uploaded or used."
-  },
-  "DJ'TEKINA//SOMETHING": {
-    "status": "partial",
-    "notes": "Tracks from or themed around Touhou should not be uploaded or used."
-  },
-  "Zekk": {
-    "status": "partial",
-    "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
-  },
-  "40mP": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "ak+q": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "DJMax": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Neowiz": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Draw the Emotional": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Enter Shikari": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "EZFG": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Hatsuki Yura": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Igorrr": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "kamome sano": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "Kozato": {
-    "status": "disallowed",
-    "notes": null
-  },
-  "NOMA": {
-    "status": "disallowed",
-    "notes": null
-  }
+    "a_hisa": {
+        "status": "partial",
+        "notes": "Contact before uploading. Can be reached via email or Bandcamp."
+    },
+    "ak+q": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "Akira Complex": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "HoneyComeBear": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "Jun Kuroda": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "Morimori Atsushi": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "Synthion": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "Yuyoyuppe": {
+        "status": "partial",
+        "notes": "Tracks from or themed around Touhou should not be uploaded or used."
+    },
+    "DJ'TEKINA//SOMETHING": {
+        "status": "partial",
+        "notes": "Tracks from or themed around Touhou should not be uploaded or used."
+    },
+    "Zekk": {
+        "status": "partial",
+        "notes": "Do not use or upload tracks that are not available on the creator's Featured Artist listing."
+    },
+    "40mP": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "DJMax": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Neowiz": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Draw the Emotional": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Enter Shikari": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "EZFG": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Hatsuki Yura": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Igorrr": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "kamome sano": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "Kozato": {
+        "status": "disallowed",
+        "notes": null
+    },
+    "NOMA": {
+        "status": "disallowed",
+        "notes": null
+    }
 }

--- a/server/constants/artist-permissions/overrides.json
+++ b/server/constants/artist-permissions/overrides.json
@@ -1,7 +1,12 @@
 [
-  {
-    "title": "Tits or get the fuck out!!",
-    "artist": "Morimori Atsushi",
-    "status": "allowed"
-  }
+    {
+        "title": "Tits or get the fuck out!!",
+        "artist": "Morimori Atsushi",
+        "status": "allowed"
+    },
+    {
+        "title": "execution_program",
+        "artist": "Lusumi",
+        "status": "disallowed"
+    }
 ]

--- a/server/constants/artist-permissions/overrides.json
+++ b/server/constants/artist-permissions/overrides.json
@@ -5,7 +5,7 @@
         "status": "allowed"
     },
     {
-        "title": "execution_program",
+        "title": "/execution_program.wav",
         "artist": "Lusumi",
         "status": "disallowed"
     }


### PR DESCRIPTION
- Updates ak+q re: FA announcement
- Updates track `execution_program` re: https://github.com/ppy/osu-wiki/pull/12926
- Adds Lusumi to `partial` listing, mainly in the case of the override not triggering (graveyard not having the right title or something).